### PR TITLE
Kaka: 调整背景颜色

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,78 @@
 .App {
   text-align: center;
+  position: relative;
+}
+
+/* 主题切换按钮样式 */
+.theme-toggle {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  border: 2px solid currentColor;
+  background-color: transparent;
+  font-size: 24px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.3s ease;
+  z-index: 1000;
+}
+
+.theme-toggle:hover {
+  transform: scale(1.1);
+  opacity: 0.8;
+}
+
+/* 浅色主题 */
+.App.light {
+  background-color: #f5f5f5;
+  color: #333;
+}
+
+.App.light .theme-toggle {
+  color: #333;
+  background-color: #fff;
+}
+
+.App.light .App-header {
+  background-color: #ffffff;
+  color: #333;
+}
+
+.App.light .App-version {
+  color: #666;
+}
+
+.App.light .App-description {
+  color: #888;
+}
+
+/* 深色主题 */
+.App.dark {
+  background-color: #1a1a1a;
+  color: #fff;
+}
+
+.App.dark .theme-toggle {
+  color: #fff;
+  background-color: #282c34;
+}
+
+.App.dark .App-header {
+  background-color: #282c34;
+  color: white;
+}
+
+.App.dark .App-version {
+  color: #8899a6;
+}
+
+.App.dark .App-description {
+  color: #a0a0a0;
 }
 
 .App-logo {
@@ -14,14 +87,13 @@
 }
 
 .App-header {
-  background-color: #282c34;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   font-size: calc(10px + 2vmin);
-  color: white;
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 .App-link {
@@ -30,15 +102,15 @@
 
 .App-version {
   font-size: calc(8px + 1.5vmin);
-  color: #8899a6;
   margin-top: 20px;
+  transition: color 0.3s ease;
 }
 
 .App-description {
   font-size: calc(8px + 1.5vmin);
-  color: #a0a0a0;
   margin-top: 10px;
   max-width: 600px;
+  transition: color 0.3s ease;
 }
 
 @keyframes App-logo-spin {

--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,34 @@
+import { useState, useEffect } from 'react';
 import logo from './logo.svg';
 import './App.css';
 
 function App() {
+  // 从 localStorage 读取主题设置,默认为 'light'
+  const [theme, setTheme] = useState(() => {
+    const savedTheme = localStorage.getItem('theme');
+    return savedTheme || 'light';
+  });
+
+  // 当主题改变时,更新 localStorage 和 document class
+  useEffect(() => {
+    localStorage.setItem('theme', theme);
+    document.documentElement.className = theme;
+  }, [theme]);
+
+  // 切换主题
+  const toggleTheme = () => {
+    setTheme(prevTheme => prevTheme === 'light' ? 'dark' : 'light');
+  };
+
   return (
-    <div className="App">
+    <div className={`App ${theme}`}>
+      <button
+        className="theme-toggle"
+        onClick={toggleTheme}
+        aria-label="切换主题"
+      >
+        {theme === 'light' ? '🌙' : '☀️'}
+      </button>
       <header className="App-header">
         <img src={logo} className="App-logo" alt="logo" />
         <p>


### PR DESCRIPTION

**关联 Issue**: #10 | **用时**: 52.8秒

---

## 原 Issue：调整背景颜色

```
1. 页面布局不变
2. 右上角新增设置深色和浅色模式
3. 默认为浅色
```

---

## Kaka 开发总结

完美!任务已成功完成。以下是开发总结:

---

## Issue #10 开发总结 - 调整背景颜色

### ✅ 完成情况

已成功实现深色和浅色主题切换功能,所有需求均已满足:

1. ✅ **页面布局保持不变** - 保持了原有的居中布局和内容结构
2. ✅ **右上角新增主题切换按钮** - 添加了圆形按钮,点击可在深色/浅色模式间切换
3. ✅ **默认为浅色模式** - 首次访问时默认使用浅色主题

### 🔧 技术实现

#### 核心功能 (src/App.js)
- 使用 `useState` Hook 管理主题状态,支持 `'light'` 和 `'dark'` 两种模式
- 使用 `useEffect` Hook 实现主题持久化,自动保存到 `localStorage`
- 主题切换按钮使用 emoji 图标(🌙/☀️)直观显示当前模式
- 按钮位置固定在右上角,响应式设计

#### 样式设计 (src/App.css)
- **浅色主题**: 白色背景 (#ffffff),深色文字 (#333),柔和的辅助色
- **深色主题**: 深色背景 (#282c34),浅色文字,保持原有的配色方案
- 添加平滑过渡动画 (transition: 0.3s ease)
- 按钮悬停效果 (scale 1.1 + 透明度变化)

### 📝 关键特性

1. **状态持久化**: 用户选择的主题会保存在浏览器 localStorage 中,刷新页面后自动恢复
2. **无障碍支持**: 按钮包含 `aria-label` 属性
3. **用户体验**: 平滑的颜色过渡,直观的图标切换
4. **代码质量**: 通过 `npm run build` 构建验证,无错误和警告

### 📦 提交信息

```
feat: 实现深色和浅色主题切换功能

- 在右上角添加主题切换按钮,支持深色和浅色模式切换
- 使用 useState 和 useEffect 管理主题状态
- 将主题设置持久化到 localStorage,刷新页面后保持用户选择
- 默认使用浅色主题
- 优化 CSS 样式,为两种主题提供不同的配色方案
- 添加平滑的过渡动画效果
```

提交哈希: `935f0055`

---

@wersling 请 review 后决策是否 PR，谢谢！
